### PR TITLE
Make `prodigal_train` remove training file if it already exists

### DIFF
--- a/compare.py
+++ b/compare.py
@@ -21,6 +21,9 @@ def prodigal_train(genome: Path, train_file: Path, prodigal_bin: Path, closed: b
     :param closed: Closed ends.
     :param transl_table: Translation table (11)
     """
+    if Path(train_file).exists():
+        os.remove(train_file)
+
     cmd = [
         prodigal_bin,
         '-i', str(genome),


### PR DESCRIPTION
This PR makes the `prodigal_train` function remove the training file if it already exists.

If you don't do this, `prodigal_train` will not actually create a new train file, it will reuse the existing one. This means that if you run the analysis in `closed=False` first and then in `closed=True` Prodigal will always used the training from the `closed=False` run, so of course you'll get mismatches in the second run.